### PR TITLE
[Feat} 멋사 스프링 5주차 과제

### DIFF
--- a/spring/week05/seminar/src/main/java/org/example/seminar/controller/BoardController.java
+++ b/spring/week05/seminar/src/main/java/org/example/seminar/controller/BoardController.java
@@ -1,0 +1,51 @@
+package org.example.seminar.controller;
+
+import org.example.seminar.dto.BoardDto;
+import org.example.seminar.service.BoardService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@ResponseBody
+@RequestMapping("board")
+public class BoardController {
+    private static final Logger logger = LoggerFactory.getLogger(BoardController.class);
+    private final BoardService boardService;
+
+    public BoardController(@Autowired BoardService boardService) {
+        this.boardService = boardService;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public void createBoard(@RequestBody BoardDto boardDto) {
+        this.boardService.createBoard(boardDto);
+    }
+
+    @GetMapping("{id}")
+    public BoardDto readBoard(@PathVariable("id") Long id) {
+        return this.boardService.readBoard(id);
+    }
+
+    @GetMapping
+    public List<BoardDto> readBoardsAll() {
+        return this.boardService.readBoardsAll();
+    }
+
+    @PatchMapping("{id}")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public void updateBoard(@PathVariable("id") Long id, @RequestBody BoardDto boardDto) {
+        this.boardService.updateBoard(id, boardDto);
+    }
+
+    @DeleteMapping("{id}")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public void deleteBoard(@PathVariable("id") Long id) {
+        this.boardService.deleteBoard(id);
+    }
+}

--- a/spring/week05/seminar/src/main/java/org/example/seminar/dao/BoardDao.java
+++ b/spring/week05/seminar/src/main/java/org/example/seminar/dao/BoardDao.java
@@ -1,0 +1,66 @@
+package org.example.seminar.dao;
+
+import org.example.seminar.dto.BoardDto;
+import org.example.seminar.entity.BoardEntity;
+import org.example.seminar.repository.BoardRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Iterator;
+import java.util.Optional;
+
+@Repository
+public class BoardDao {
+    private static final Logger logger = LoggerFactory.getLogger(BoardDao.class);
+    private final BoardRepository boardRepository;
+
+    public BoardDao(@Autowired BoardRepository boardRepository) {
+        this.boardRepository = boardRepository;
+    }
+
+    // CREATE
+    public void createBoard(BoardDto dto) {
+        BoardEntity boardEntity = new BoardEntity();
+        boardEntity.setName(dto.getName());
+        this.boardRepository.save(boardEntity);
+    }
+
+    // READ (단일)
+    public BoardEntity readBoard(Long id) {
+        Optional<BoardEntity> boardEntity = this.boardRepository.findById(id);
+        if (boardEntity.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+        }
+        return boardEntity.get();
+    }
+
+    // READ (전체)
+    public Iterator<BoardEntity> readBoardAll() {
+        return this.boardRepository.findAll().iterator();
+    }
+
+    // UPDATE
+    public void updateBoard(Long id, BoardDto dto ) {
+        Optional<BoardEntity> targetEntity = this.boardRepository.findById(id);
+        if (targetEntity.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+        }
+        BoardEntity boardEntity = targetEntity.get();
+        boardEntity.setName(dto.getName() == null ? boardEntity.getName() : dto.getName());
+        this.boardRepository.save(boardEntity);
+    }
+
+    // DELETE
+    public void deleteBoard(Long id) {
+        Optional<BoardEntity> targetEntity = this.boardRepository.findById(id);
+        if (targetEntity.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+        }
+        this.boardRepository.delete(targetEntity.get());
+    }
+
+}

--- a/spring/week05/seminar/src/main/java/org/example/seminar/dao/PostDao.java
+++ b/spring/week05/seminar/src/main/java/org/example/seminar/dao/PostDao.java
@@ -2,7 +2,9 @@ package org.example.seminar.dao;
 
 
 import org.example.seminar.dto.PostDto;
+import org.example.seminar.entity.BoardEntity;
 import org.example.seminar.entity.PostEntity;
+import org.example.seminar.repository.BoardRepository;
 import org.example.seminar.repository.PostRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,9 +20,11 @@ import java.util.Optional;
 public class PostDao {
     private static final Logger logger = LoggerFactory.getLogger(PostDao.class);
     private final PostRepository postRepository;
+    private final BoardRepository boardRepository;
 
-    public PostDao(@Autowired PostRepository postRepository) {
+    public PostDao(@Autowired PostRepository postRepository, @Autowired BoardRepository boardRepository) {
         this.postRepository = postRepository;
+        this.boardRepository = boardRepository;
     }
 
     public void createPost(PostDto dto){
@@ -28,7 +32,11 @@ public class PostDao {
         postEntity.setTitle(dto.getTitle());
         postEntity.setContent(dto.getContent());
         postEntity.setWriter(dto.getWriter());
-        postEntity.setBoardEntity(null);
+        Optional<BoardEntity> boardEntity = this.boardRepository.findById((long)dto.getBoardId());
+        if (boardEntity.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+        }
+        postEntity.setBoardEntity(boardEntity.get());
 
         this.postRepository.save(postEntity);
     }

--- a/spring/week05/seminar/src/main/java/org/example/seminar/dto/BoardDto.java
+++ b/spring/week05/seminar/src/main/java/org/example/seminar/dto/BoardDto.java
@@ -15,5 +15,5 @@ import java.util.List;
 public class BoardDto {
     private Long id;
     private String name;
-    private List<PostDto> posts = new ArrayList<>();
+    private List<Long> postIds;
 }

--- a/spring/week05/seminar/src/main/java/org/example/seminar/dto/BoardDto.java
+++ b/spring/week05/seminar/src/main/java/org/example/seminar/dto/BoardDto.java
@@ -1,0 +1,19 @@
+package org.example.seminar.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BoardDto {
+    private Long id;
+    private String name;
+    private List<PostDto> posts = new ArrayList<>();
+}

--- a/spring/week05/seminar/src/main/java/org/example/seminar/entity/BoardEntity.java
+++ b/spring/week05/seminar/src/main/java/org/example/seminar/entity/BoardEntity.java
@@ -22,7 +22,8 @@ public class BoardEntity {
     @OneToMany(
             targetEntity = PostEntity.class,
             fetch = FetchType.LAZY,
-            mappedBy = "boardEntity"
+            mappedBy = "boardEntity",
+            cascade = CascadeType.ALL
     )
     private List<PostEntity> postEntityList = new ArrayList<>();
 }

--- a/spring/week05/seminar/src/main/java/org/example/seminar/service/BoardService.java
+++ b/spring/week05/seminar/src/main/java/org/example/seminar/service/BoardService.java
@@ -3,6 +3,7 @@ package org.example.seminar.service;
 import org.example.seminar.dao.BoardDao;
 import org.example.seminar.dto.BoardDto;
 import org.example.seminar.entity.BoardEntity;
+import org.example.seminar.entity.PostEntity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,10 +30,15 @@ public class BoardService {
     // READ (단일)
     public BoardDto readBoard(Long id) {
         BoardEntity boardEntity = this.boardDao.readBoard(id);
+        List<Long> postIds = new ArrayList<>();
+        for (PostEntity postEntity : boardEntity.getPostEntityList()) {
+            postIds.add(postEntity.getId());
+        }
+
         return new BoardDto(
                 boardEntity.getId(),
                 boardEntity.getName(),
-                new ArrayList<>()
+                postIds
         );
     }
 
@@ -42,10 +48,16 @@ public class BoardService {
         List<BoardDto> boardDtoList = new ArrayList<>();
         while (iterator.hasNext()) {
             BoardEntity boardEntity = iterator.next();
+
+            List<Long> postIds = new ArrayList<>();
+            for (PostEntity postEntity : boardEntity.getPostEntityList()) {
+                postIds.add(postEntity.getId());
+            }
+
             boardDtoList.add(new BoardDto(
                     boardEntity.getId(),
                     boardEntity.getName(),
-                    new ArrayList<>()
+                    postIds
             ));
         }
         return boardDtoList;

--- a/spring/week05/seminar/src/main/java/org/example/seminar/service/BoardService.java
+++ b/spring/week05/seminar/src/main/java/org/example/seminar/service/BoardService.java
@@ -1,0 +1,64 @@
+package org.example.seminar.service;
+
+import org.example.seminar.dao.BoardDao;
+import org.example.seminar.dto.BoardDto;
+import org.example.seminar.entity.BoardEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+@Service
+public class BoardService {
+    private static final Logger logger = LoggerFactory.getLogger(BoardService.class);
+    private final BoardDao boardDao;
+
+    public BoardService(@Autowired BoardDao boardDao) {
+        this.boardDao = boardDao;
+    }
+
+    // CREATE
+    public void createBoard(BoardDto dto){
+        this.boardDao.createBoard(dto);
+    }
+
+    // READ (단일)
+    public BoardDto readBoard(Long id) {
+        BoardEntity boardEntity = this.boardDao.readBoard(id);
+        return new BoardDto(
+                boardEntity.getId(),
+                boardEntity.getName(),
+                new ArrayList<>()
+        );
+    }
+
+    // READ (전체)
+    public List<BoardDto> readBoardsAll() {
+        Iterator<BoardEntity> iterator = this.boardDao.readBoardAll();
+        List<BoardDto> boardDtoList = new ArrayList<>();
+        while (iterator.hasNext()) {
+            BoardEntity boardEntity = iterator.next();
+            boardDtoList.add(new BoardDto(
+                    boardEntity.getId(),
+                    boardEntity.getName(),
+                    new ArrayList<>()
+            ));
+        }
+        return boardDtoList;
+    }
+
+    // UPDATE
+    public void updateBoard(Long id, BoardDto dto) {
+        this.boardDao.updateBoard(id, dto);
+    }
+
+    // DELETE
+    public void deleteBoard(Long id) {
+        this.boardDao.deleteBoard(id);
+    }
+
+}


### PR DESCRIPTION
## 📌 관련 이슈
  closed #43 


## ✨ 과제 내용
<!-- 과제에 대한 설명을 적어주세요 -->
## 📝BoardEntity 기반 CRUD API 구현 및 계층 역할 정리📝
이번 과제는 게시판에 대한 RESTful CRUD API를 구현하는 것이었습니다. JPA를 활용하여 H2 데이터베이스와 연동했으며, Controller, Service, DAO, Repository 계층으로 역할을 분리하여 설계했습니다!

### 1. Controller 계층
- BoardController, PostController
- 클라이언트의 HTTP 요청을 받아들이는 API의 진입점입니다. 요청 데이터를 Service 계층으로 전달하고, Service 계층의 응답을 받아 HTTP 상태 코드와 함께 클라이언트에게 반환합니다.

### 2. Service 계층
- BoardService, PostService
- 비즈니스 로직을 처리하는 핵심 계층입니다. DAO를 통해 데이터를 조작하고, DTO와 Entity 객체 간의 데이터 변환을 담당합니다.

### 3. DAO 계층
- BoardDao, PostDao
- 데이터베이스 접근을 담당합니다. Service 계층의 요청을 받아 Repository를 통해 데이터베이스에 데이터를 저장,조회,수정,삭제 합니다.

### 4. Entity
- Entity는 데이터베이스 테이블과 매핑됩니다.

### 5. DTO
- DTO는 계층 간 데이터 전송을 위한 객체입니다.
- 데이터 저장이나 변경 없이 데이터만 전달합니다.

### 🫧각 API별 구현 내용 및 흐름🫧
### 1. 게시판 생성  (POST /board)
- 클라이언트가 BoardDto를 담아 POST 요청을 보냄 -> BoardController는 이를 받아 BoardService.createBoard()를 호출함 -> BoardService는 받은 BoardDto를 BoardEntity로 변환하여 BoardDao.createBoard()에 전달->BoardRepository를 통해 DB에 저장

### 2. 게시판 단일/전체 조회 (GET /board/{id} 또는 /board)
- 클라이언트가 GET 요청을 보냄 -> BoardController는 ID 또는 전체 목록 조회 요청을 BoardService로 전달 -> BoardService는 BoardDao를 통해 BoardEntity 조회 -> 이를 BoardDto로 변환하여 반환
- 겪은 문제 및 해결 과정
  - Controller의 @PathVariable 인자(int)와 Service의 메서드 인자(Long) 간의 타입 불일치 오류가 발생했습니다. => 모든 계층의 ID 타입을 Long으로 통일하여 문제를 해결했습니다.
  - 지금처럼 DTO를 게시글의 ID만 추출해 담기 전에는 게시글의 객체 자체를 담는 로직이었습니다. 이때 게시판을 조회하면 posts 필드가 비어있는 문제가 발생했는데 이는 BoardEntity의 postEntityList가 FetchType.LAZY (지연로딩)로 설정되어 있었기 때문입니다. => BoardService의 readBoard 메서드에서 boardEntity.getPostEntityList()에 접근하여 게시글의 ID만 추출해 DTO에 담아주는 로직을 추가하여 해결했습니다.

### 3. 게시판 수정 (PATCH /board/{id})
- 클라이언트가 BoardDto를 담아 PATCH 요청을 보냄 -> BoardController는 이를 받아 BoardService.updateBoard()를 호출 -> BoardService는 받은 id와 DTO를 BoardDao에 전달 -> DAO는 BoardRepository를 통해 DB 업데이트

### 4. 게시판 삭제 (DELETE /board/{id})
- 클라이언트가 DELETE 요청을 보냄 -> Service와 DAO를 통해 삭제 작업 수행
- 겪은 문제 및 해결 과정
  - 게시판을 생성한 후, 게시글을 생성하려고 할 때 boardId가 PostEntity에 제대로 매핑되지 않아 BOARD_ID가 null로 저장되는 문제가 발생했습니다. => PostDao에 BoardRepository를 주입받아 PostDto의 boardId로 BoardEntity를 조회하고, 이를 PostEntity에 할당하는 로직을 추가하여 외래 키가 올바르게 저장되도록 했습니다.
  - 게시판을 삭제할 때 500 INTERNAL SERVER ERROR가 발생했습니다. 이는 외래키 제약 조건 위반 때문으로 PostEntity의 board_id가 BoardEntity를 참조하고 있는 상태에서 게시판을 먼저 삭제하려 했기 때문입니다. => BoardEntity에 cascade 옵션을 추가하여 부모 엔티티 삭제 시 자식 엔티티도 함께 삭제되도록 하여 해결하였습니다.

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
### 1. 게시판 생성
<img width="1235" height="1032" alt="스크린샷 2025-08-31 124818" src="https://github.com/user-attachments/assets/995d50b1-c66c-4652-82c8-d30f06423766" />
숙멋 게시판1 생성
id는 데이터베이스의 Auto-increment로 자동 증가되어 부여됨
<img width="1247" height="1094" alt="스크린샷 2025-08-31 125004" src="https://github.com/user-attachments/assets/8b680560-4428-402f-aeff-6682d4b4ea39" />
숙멋 게시판1에 글 생성해줌

### 2. 게시판 단일/전체 조회
<img width="1230" height="1029" alt="스크린샷 2025-08-31 133202" src="https://github.com/user-attachments/assets/f918ec56-172f-49db-946c-26d40c98d267" />
id가 1인 게시판 단일 조회
<img width="1215" height="936" alt="스크린샷 2025-08-31 133215" src="https://github.com/user-attachments/assets/157fa7af-fbb4-4c1d-a3f9-e7defa078095" />
존재하지 않는 게시판의 id인 경우 404 Not Found 발생
<img width="1229" height="1391" alt="스크린샷 2025-08-31 133232" src="https://github.com/user-attachments/assets/c50222ad-675c-4e11-aa64-653e91446e8c" />
게시판 전체 조회

### 3. 게시판 수정
<img width="1243" height="861" alt="스크린샷 2025-08-31 133350" src="https://github.com/user-attachments/assets/2bc376a3-feff-4301-80d3-715375894de6" />
게시판 수정 성공 시 202 Accepted
<img width="1240" height="1050" alt="스크린샷 2025-08-31 133415" src="https://github.com/user-attachments/assets/06bb4977-c5d6-4152-8970-4bca01691b37" />
게시판의 이름이 잘 수정된 것을 확인할 수 있음
<img width="1228" height="1045" alt="스크린샷 2025-08-31 133359" src="https://github.com/user-attachments/assets/3167de84-0d50-4782-9d44-073e7a694204" />
존재하지 않는 게시판의 id인 경우 404 Not Found 발생

### 4. 게시판 삭제
<img width="1241" height="830" alt="스크린샷 2025-08-31 133459" src="https://github.com/user-attachments/assets/3f650f30-615e-47ef-9f45-e434310af344" />
삭제 성공 시 202 Accepted
<img width="1241" height="957" alt="스크린샷 2025-08-31 133513" src="https://github.com/user-attachments/assets/c3912a09-3f34-436c-b128-dde83f0a75f6" />
삭제 된 id 1 게시물이 조회되지 않는 것을 확인할 수 있다.
<img width="1245" height="985" alt="스크린샷 2025-08-31 133525" src="https://github.com/user-attachments/assets/37e12666-356a-4de2-b886-89ea9dbc1c34" />
존재하지 않는 게시판의 id인 경우 404 Not Found 발생






## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 --> 
- 평소에는 DAO를 생략하고 Service에서 바로 Repository를 썼는데 DAO를 따로 분리해보니 확실한 장점이 있는 것 같다. 일단 Service가 비즈니스 로직을 처리하는 데만 집중할 수 있어서 코드가 엄청 깔끔해졌다 ! 전에는 DB 접근하는 코드랑 비즈니스 로직이 한 파일에 섞여 있어서 복잡했는데 DAO가 데이터베이스 접근을 다 맡아주니가 역할이 딱 나누어지는 느낌이다. 특히 PostDao에서 boardId로 BoardEntity를 찾아 외래키를 직접 연결하는 로직을 DAO에 넣으니까 Service에 BoardRepository를 가져오지 않아도 되서 코드가 깔끔해진 것 같다.