### PR TITLE
[Feat] 멋사 스프링 7주차 과제

### DIFF
--- a/spring/week07/seminar/src/main/java/org/example/seminar/entity/Board.java
+++ b/spring/week07/seminar/src/main/java/org/example/seminar/entity/Board.java
@@ -1,0 +1,39 @@
+package org.example.seminar.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+@Table(name = "board")
+public class Board extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "writer_id")
+    @ToString.Exclude
+    private Writer writer;
+
+    @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @ToString.Exclude
+    private List<Comment> comments = new ArrayList<>();
+
+    public void addComment(Comment comment) {
+        this.comments.add(comment);
+        comment.setBoard(this);
+    }
+}

--- a/spring/week07/seminar/src/main/java/org/example/seminar/entity/Comment.java
+++ b/spring/week07/seminar/src/main/java/org/example/seminar/entity/Comment.java
@@ -1,0 +1,30 @@
+package org.example.seminar.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+@Table(name = "comment")
+public class Comment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "writer_id")
+    @ToString.Exclude
+    private Writer writer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id")
+    @ToString.Exclude
+    private Board board;
+}

--- a/spring/week07/seminar/src/main/java/org/example/seminar/entity/Writer.java
+++ b/spring/week07/seminar/src/main/java/org/example/seminar/entity/Writer.java
@@ -1,0 +1,39 @@
+package org.example.seminar.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+@Table(name = "writer")
+public class Writer extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private int age;
+
+    @OneToMany(mappedBy = "writer", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @ToString.Exclude
+    private List<Board> boards = new ArrayList<>();
+
+    @OneToMany(mappedBy = "writer", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @ToString.Exclude
+    private List<Comment> comments = new ArrayList<>();
+
+    public void addBoard(Board board) {
+        this.boards.add(board);
+        board.setWriter(this);
+    }
+
+}

--- a/spring/week07/seminar/src/main/java/org/example/seminar/repository/BoardRepository.java
+++ b/spring/week07/seminar/src/main/java/org/example/seminar/repository/BoardRepository.java
@@ -1,0 +1,7 @@
+package org.example.seminar.repository;
+
+import org.example.seminar.entity.Board;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardRepository extends JpaRepository<Board, Long> {
+}

--- a/spring/week07/seminar/src/main/java/org/example/seminar/repository/CommentRepository.java
+++ b/spring/week07/seminar/src/main/java/org/example/seminar/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package org.example.seminar.repository;
+
+import org.example.seminar.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/spring/week07/seminar/src/main/java/org/example/seminar/repository/WriterRepository.java
+++ b/spring/week07/seminar/src/main/java/org/example/seminar/repository/WriterRepository.java
@@ -1,0 +1,7 @@
+package org.example.seminar.repository;
+
+import org.example.seminar.entity.Writer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WriterRepository extends JpaRepository<Writer, Long> {
+}

--- a/spring/week07/seminar/src/test/java/org/example/seminar/repository/BoardRepositoryTest.java
+++ b/spring/week07/seminar/src/test/java/org/example/seminar/repository/BoardRepositoryTest.java
@@ -1,0 +1,64 @@
+package org.example.seminar.repository;
+
+import org.example.seminar.entity.Board;
+import org.example.seminar.entity.Comment;
+import org.example.seminar.entity.Writer;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class BoardRepositoryTest {
+
+    @Autowired
+    BoardRepository boardRepository;
+
+    @Autowired
+    WriterRepository writerRepository;
+
+    // 다대일 관계 조회: Board 조회 시 연관된 Writer 정보 확인
+    @Test
+    void findBoardWithWriterTest() {
+        Writer writer = new Writer();
+        writer.setName("이혜지");
+        writerRepository.save(writer);
+
+        Board board = new Board();
+        board.setTitle("이혜지의 첫 게시물");
+        board.setWriter(writer);
+        boardRepository.save(board);
+
+        System.out.println("--- Board를 작성한 Writer 정보 ---");
+        Board foundBoard = boardRepository.findById(board.getId()).get();
+        System.out.println("게시글 제목: " + foundBoard.getTitle());
+        System.out.println("게시글 작성자: " + foundBoard.getWriter().getName());
+    }
+
+    // 일대다 관계 조회: Board 조회 시 연관된 Comment 목록 확인
+    @Test
+    void findBoardWithCommentsTest() {
+        Board board = new Board();
+        board.setTitle("댓글이 달린 게시글");
+
+        Comment comment1 = new Comment();
+        comment1.setContent("첫 번째 댓글입니다.");
+
+        Comment comment2 = new Comment();
+        comment2.setContent("두 번째 댓글입니다.");
+
+        board.addComment(comment1);
+        board.addComment(comment2);
+        boardRepository.save(board);
+
+        System.out.println("--- Board에 달린 Comment 목록 ---");
+        Board foundBoard = boardRepository.findById(board.getId()).get();
+        for (Comment comment : foundBoard.getComments()) {
+            System.out.println("댓글 내용: " + comment.getContent());
+        }
+    }
+
+
+
+}

--- a/spring/week07/seminar/src/test/java/org/example/seminar/repository/CommentRepositoryTest.java
+++ b/spring/week07/seminar/src/test/java/org/example/seminar/repository/CommentRepositoryTest.java
@@ -1,0 +1,103 @@
+package org.example.seminar.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.example.seminar.entity.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@SpringBootTest
+@Transactional
+class CommentRepositoryTest {
+
+    @Autowired
+    EntityManager em;
+    private JPAQueryFactory queryFactory;
+
+    @Autowired
+    WriterRepository writerRepository;
+
+    @Autowired
+    BoardRepository boardRepository;
+
+    @Autowired
+    CommentRepository commentRepository;
+
+    @BeforeEach
+    void setUp() {
+        queryFactory = new JPAQueryFactory(em);
+
+        Writer writerA = new Writer();
+        writerA.setName("이혜지");
+        writerA.setAge(25);
+
+        Writer writerB = new Writer();
+        writerB.setName("김숙멋");
+        writerB.setAge(26);
+        writerRepository.saveAll(List.of(writerA, writerB));
+
+        Board board = new Board();
+        board.setTitle("QueryDSL 테스트용 게시글");
+        board.setContent("내용입니다.");
+        board.setWriter(writerA);
+        boardRepository.save(board);
+
+        Comment comment1 = new Comment();
+        comment1.setContent("이혜지의 첫 댓글입니다.");
+        comment1.setWriter(writerA);
+        comment1.setBoard(board);
+
+        Comment comment2 = new Comment();
+        comment2.setContent("김숙멋의 첫 번째 댓글입니다.");
+        comment2.setWriter(writerB);
+        comment2.setBoard(board);
+
+        Comment comment3 = new Comment();
+        comment3.setContent("이혜지의 두 번째 댓글입니다.");
+        comment3.setWriter(writerA);
+        comment3.setBoard(board);
+
+        commentRepository.saveAll(List.of(comment1, comment2, comment3));
+    }
+
+    @Test
+    // 특정 작성자가 쓴 댓글 조회
+    void queryDslBasicTest() {
+        QComment qComment = QComment.comment;
+
+        List<Comment> comments = queryFactory
+                .selectFrom(qComment)
+                .where(qComment.writer.name.eq("이혜지"))
+                .fetch();
+
+        System.out.println("--- '이혜지'가 작성한 댓글 목록 ---");
+        for (Comment comment : comments) {
+            System.out.println(comment.getContent());
+        }
+    }
+
+    @Test
+    // 댓글 내용과 작성자 이름 선택적으로 조회
+    void queryDslProjectionTest() {
+        QComment qComment = QComment.comment;
+        QWriter qWriter = QWriter.writer;
+
+        List<com.querydsl.core.Tuple> result = queryFactory
+                .select(qComment.content, qWriter.name)
+                .from(qComment)
+                .join(qComment.writer, qWriter)
+                .fetch();
+
+        System.out.println("--- 댓글 내용과 작성자 이름 목록 ---");
+        for (com.querydsl.core.Tuple tuple : result) {
+            String content = tuple.get(qComment.content);
+            String writerName = tuple.get(qWriter.name);
+            System.out.println("댓글 내용: " + content + " | 작성자: " + writerName);
+        }
+    }
+}

--- a/spring/week07/seminar/src/test/java/org/example/seminar/repository/WriterRepositoryTest.java
+++ b/spring/week07/seminar/src/test/java/org/example/seminar/repository/WriterRepositoryTest.java
@@ -1,0 +1,45 @@
+package org.example.seminar.repository;
+
+import org.example.seminar.entity.Board;
+import org.example.seminar.entity.Writer;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+class WriterRepositoryTest {
+
+    @Autowired
+    WriterRepository writerRepository;
+
+    @Autowired
+    BoardRepository boardRepository;
+
+    // Cascade 테스트: Writer 저장 시 Board 함께 저장
+    @Test
+    void cascadePersistTest() {
+        Writer writer = new Writer();
+        writer.setName("이혜지");
+
+        Board board1 = new Board();
+        board1.setTitle("첫 번째 게시물");
+        board1.setContent("첫 번째 게시물의 내용입니다.");
+
+        Board board2 = new Board();
+        board2.setTitle("두 번째 게시물");
+        board2.setContent("두 번째 게시물의 내용입니다.");
+
+        writer.addBoard(board1);
+        writer.addBoard(board2);
+
+        writerRepository.save(writer);
+
+        System.out.println("--- Writer가 작성한 Board 목록 ---");
+        Writer foundWriter = writerRepository.findById(writer.getId()).get();
+        for (Board board : foundWriter.getBoards()) {
+            System.out.println("게시글 제목: " + board.getTitle() + " | 게시글 내용: " + board.getContent());
+        }
+    }
+}

--- a/spring/week07/seminar/src/test/java/org/example/seminar/repository/WriterRepositoryTest.java
+++ b/spring/week07/seminar/src/test/java/org/example/seminar/repository/WriterRepositoryTest.java
@@ -14,9 +14,6 @@ class WriterRepositoryTest {
     @Autowired
     WriterRepository writerRepository;
 
-    @Autowired
-    BoardRepository boardRepository;
-
     // Cascade 테스트: Writer 저장 시 Board 함께 저장
     @Test
     void cascadePersistTest() {


### PR DESCRIPTION
## 📌 관련 이슈
  closed #49 


## ✨ 과제 내용
<!-- 과제에 대한 설명을 적어주세요 -->
## 📝Board, Writer, Comment 엔티티 매핑 구현하기
### 1. 엔티티 연관관계 매핑
1) Writer : Board (1:N)
- Writer는 여러 Board를, Board는 하나의 Writer를 갖는 관계입니다. 
- Writer의 boards:` @OneToMany(mappedBy="writer")`를 사용하여 연관관계의 주인이 아님을 명시했습니다. 
-` fetch = FetchType.LAZY`: Writer를 조회할 때마다 연관된 모든 Board를 함께 조회하는 N+1 문제를 방지하기 위해 지연 로딩을 적용했습니다.
- `cascade = CascadeType.ALL`: Writer의 생명주기에 Board가 종속되도록 하여 Writer 저장 시 연관된 Board가 함께 저장되도록 구현했습니다.
- Board의 writer: `@ManyToOne`과 `@JoinColumn(name="writer_id")`을 사용하여 연관관계의 주인이자 외래 키를 관리하도록 설정했습니다.

2) Board : Comment (1:N)
- Board는 여러 Comment를, Comment는 하나의 Board를 갖는 관계입니다. 
- Board의 comments: Writer-Board 관계와 동일하게, `@OneToMany(mappedBy="board", cascade=CascadeType.ALL)`을 적용하여 Board의 생명주기에 Comment가 종속되도록 하여 Board 저장 시 연관된 Comment가 함께 저장되도록 구현했습니다.
-  ` fetch = FetchType.LAZY`: Board를 조회할 때마다 해당 게시글의 모든 Comment를 함께 조회하는 N+1 문제를 방지하기 위해 지연 로딩을 적용했습니다.
- Comment의 writer: `@ManyToOne`과 `@JoinColumn(name="writer_id")`을 사용하여 연관관계의 주인이자 외래 키를 관리하도록 설정했습니다.

3) Writer : Comment (1:N)
- Writer는 여러 Comment를, Comment는 하나의 Writer를 갖는 관계입니다.
- Comment가 외래 키(writer_id)를 가지므로 연관관계의 주인으로 설정했습니다.
- Writer의 comments: `@OneToMany(mappedBy="writer")`를 사용하여 연관관계의 주인이 아님을 명시했습니다. 
- `fetch = FetchType.LAZY`: 이 관계 역시 지연 로딩을 기본 원칙으로 적용하여, Writer 조회 시 불필요한 Comment 데이터가 조회되지 않도록 설계했습니다.
- `cascade = CascadeType.ALL`: Writer의 생명주기에 Comment가 종속되도록 영속성 전이 옵션을 적용했습니다


### 2. 테스트 코드 구현
각 Repository 별로 세미나에서 다룬 주요 기능들을 검증할 수 있도록 테스트 코드를 작성했습니다.

1) WriterRepositoryTest
- cascadePersistTest: Writer 엔티티에 설정된 `cascade = CascadeType.ALL` 옵션이 올바르게 동작하는지 검증합니다. Writer만 저장해도 연관된 Board들이 함께 저장되는지 확인하여 영속성 전이 기능을 테스트했습니다.

2) BoardRepositoryTest
- findBoardWithWriterTest: Board를 조회할 때 `@ManyToOne`으로 매핑된 Writer 정보를 지연 로딩을 통해 정상적으로 가져오는지 확인하는 다대일 관계 조회를 테스트했습니다.
- findBoardWithCommentsTest: Board를 조회할 때 `@OneToMany`로 매핑된 Comment 목록을 정상적으로 가져오는지 확인하는 일대다 관계 조회를 테스트했습니다.

3) CommentRepositoryTest
- queryDslBasicTest: QueryDSL을 사용하여 특정 조건(where)으로 엔티티를 조회하는 기본적인 동적 쿼리 기능을 테스트했습니다.
- queryDslProjectionTest: 엔티티 전체가 아닌, 필요한 특정 컬럼(content, writer.name)만 선택적으로 조회하는 프로젝션 기능을 테스트했습니다.


## 📸 스크린샷(선택)
### 1. BoardRepositoryTest
<img width="2628" height="1052" alt="BoardRepositoryTest" src="https://github.com/user-attachments/assets/75def6f0-665b-465e-89f2-eb9b8f367425" />
게시글 조회 시 연관된 작성자와 댓글 목록이 조회되는 것을 확인할 수 있다.

### 2. CommentRepositoryTest
<img width="2638" height="1006" alt="CommentRepositoryTest" src="https://github.com/user-attachments/assets/a46bc5b3-d439-413a-95a1-236f8a74dde4" />
'이혜지'가 작성한 댓글 목록을 조건부로 조회하고, 전체 댓글의 내용과 작성자 이름을 선택적으로 조회할 수 있는 것을 확인할 수 있다. 

### 3. WriterRepositoryTest
<img width="2646" height="932" alt="WriterRepositoryTest" src="https://github.com/user-attachments/assets/d8d8e014-ee30-47e5-9989-dfadb0c1f748" />
'이혜지'라는 작성자를 저장할 때 연관된 첫 번째 게시물과 두 번째 게시물이 함께 저장되는 것을 확인할 수 있다.


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 --> 
###  Troubleshooting 🚧
### LazyInitializationException 발생 (지연 로딩 예외)
- 상황: WriterRepositoryTest와 BoardRepositoryTest를 실행하자 런타임에서 `org.hibernate.LazyInitializationException: could not initialize proxy - no Session` 라는 오류가 발생했다. 로그를 보니 foundWriter.getBoards()나 foundBoard.getWriter().getName()처럼 지연 로딩으로 설정된 엔티티에 접근하는 시점에서 문제가 생기는 것을 확인했다 !
- 원인: 엔티티의 모든 연관관계를 성능 최적화를 위해 FetchType.LAZY(지연 로딩)로 설정했었다. 이 때문에 Repository를 통해 엔티티를 조회하는 시점에 연관 데이터가 로딩되지 않았다.그런데 DB 트랜잭션이 끝난 후에 getBoards()나 getWriter() 같은 메서드를 호출하여 데이터에 접근하려고 하니 이미 DB와의 연결이 끊겨 데이터를 가져올 수 없었다.
- 해결 방법: 테스트 메서드가 끝날 때까지 DB 세션을 유지시켜주자 => 3가지 RepositoryTest 코드 상단에 `@Transactional` 어노테이션 추가 ! 덕분에 테스트 메서드 전체가 하나의 트랜잭션으로 묶여, 지연 로딩된 데이터에 접근하는 시점에도 세션이 유지되어 정상적으로 데이터를 조회할 수 있었다 ~~

### 왜 @OneToMany 는 주인이 될 수 없는가 ..❓
세미나 자료 p 37- 38가 헷갈려서 조금 찾아보았다 !
`@ManyToOne`이 붙은 엔티티 즉, 다대일에서 다수의 입장이 외래 키를 갖고 연관 관계의 주인이 된다. 이때 일쪽 엔티티를 억지로 주인으로 삼으면 심각한 성능 문제가 발생한다.
예를 들어 Writer : Board (1:N) 를 생각해보자. 일쪽이 연관 관계의 주인이 된다는 것은 자신에게 있지도 않은 다른 테이블의 외래 키를 원격으로 관리하겠다는 의미이다. (외래키는 꼭 Board에 존재해야한다.(DB의 제1정규형(1NF) 규칙)) JPA는 이 이상한 상황을 해결하기 위해 다음과 같이 동작한다 !
1. 일단 Board를 INSERT 한다. 이때는 board 객체는 자신이 어떤 writer에 속하는지 모른다. 따라서 writer_id는 null이다.
2. Writer에 Board를 추가하고 저장하는 시점에 JPA는 뒤늦게 "이 Board는 저 Writer 소속이었지" 알게 된다.
3. 이미 INSERT된 Board 테이블에 writer_id 값을 채워 넣기 위해 불필요한 UPDATE 쿼리를 추가로 실행하게 된다.
=> 이런 비효율적인 동작 때문에 꼭 `@ManyToOne` 쪽을 주인으로 삼아야 한다 !!








