### PR TITLE
[Feat] 멋사 스프링 8주차 과제

### DIFF
--- a/spring/week08/seminar/src/main/java/org/example/seminar/controller/UserController.java
+++ b/spring/week08/seminar/src/main/java/org/example/seminar/controller/UserController.java
@@ -1,0 +1,23 @@
+package org.example.seminar.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.seminar.dto.SignupRequestDTO;
+import org.example.seminar.service.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/users")
+public class UserController {
+    private final UserService userService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<String> signup(@Valid @RequestBody SignupRequestDTO signupRequestDTO) {
+        userService.signup(signupRequestDTO);
+        return ResponseEntity.status(201).body("회원가입 성공");    }
+}

--- a/spring/week08/seminar/src/main/java/org/example/seminar/dto/SignupRequestDTO.java
+++ b/spring/week08/seminar/src/main/java/org/example/seminar/dto/SignupRequestDTO.java
@@ -1,0 +1,24 @@
+package org.example.seminar.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Getter
+public class SignupRequestDTO {
+
+    @NotBlank(message = "아이디는 필수 입력 값입니다.")
+    private String username;
+
+    @NotBlank(message = "이메일은 필수 입력 값입니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+    @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+    private String password;
+}

--- a/spring/week08/seminar/src/main/java/org/example/seminar/entity/User.java
+++ b/spring/week08/seminar/src/main/java/org/example/seminar/entity/User.java
@@ -1,0 +1,26 @@
+package org.example.seminar.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false, length = 20)
+    private String username;
+
+    @Column(nullable = false, length = 50)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+}

--- a/spring/week08/seminar/src/main/java/org/example/seminar/exception/CustomExceptionHandler.java
+++ b/spring/week08/seminar/src/main/java/org/example/seminar/exception/CustomExceptionHandler.java
@@ -5,6 +5,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -30,6 +32,23 @@ public class CustomExceptionHandler {
 
         return ResponseEntity
                 .status(e.getHttpStatus().getCode())
+                .body(map);
+    }
+
+    @ExceptionHandler(value = MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e, HttpServletRequest request) {
+        LOGGER.error("Advice 내 handleMethodArgumentNotValidException 호출, URI: {}", request.getRequestURI());
+
+        FieldError fieldError = e.getBindingResult().getFieldError();
+        String errorMessage = (fieldError != null) ? fieldError.getDefaultMessage() : "Validation failed";
+
+        Map<String, String> map = new HashMap<>();
+        map.put("error type", HttpStatus.BAD_REQUEST.getMessage());
+        map.put("code", Integer.toString(HttpStatus.BAD_REQUEST.getCode()));
+        map.put("message", errorMessage);
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST.getCode())
                 .body(map);
     }
 

--- a/spring/week08/seminar/src/main/java/org/example/seminar/exception/HttpStatus.java
+++ b/spring/week08/seminar/src/main/java/org/example/seminar/exception/HttpStatus.java
@@ -7,6 +7,7 @@ public enum HttpStatus {
     UNAUTHORIZED(401, "Unauthorized"),
     FORBIDDEN(403, "Forbidden"),
     NOT_FOUND(404, "Not Found"),
+    CONFLICT(409, "Conflict"),
     INTERNAL_SERVER_ERROR(500, "Internal Server Error"),
     SERVICE_UNAVAILABLE(503, "Service Unavailable");
 

--- a/spring/week08/seminar/src/main/java/org/example/seminar/repository/UserRepository.java
+++ b/spring/week08/seminar/src/main/java/org/example/seminar/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package org.example.seminar.repository;
+
+import org.example.seminar.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByUsername(String username);
+}

--- a/spring/week08/seminar/src/main/java/org/example/seminar/service/UserService.java
+++ b/spring/week08/seminar/src/main/java/org/example/seminar/service/UserService.java
@@ -1,0 +1,39 @@
+package org.example.seminar.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.seminar.dto.SignupRequestDTO;
+import org.example.seminar.entity.User;
+import org.example.seminar.exception.CustomException;
+import org.example.seminar.exception.HttpStatus;
+import org.example.seminar.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void signup(SignupRequestDTO requestDTO) {
+        // 1. 아이디 중복 검사
+        if (userRepository.existsByUsername(requestDTO.getUsername())) {
+            throw new CustomException(HttpStatus.CONFLICT, "이미 사용 중인 아이디입니다.");
+        }
+
+        // 2. 이메일 도메인 검사
+        if (!requestDTO.getEmail().endsWith("@sookmyung.ac.kr")) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, "숙명대학교 이메일만 사용할 수 있습니다.");
+        }
+
+        // 3. User 엔티티 생성
+        User user = User.builder()
+                .username(requestDTO.getUsername())
+                .email(requestDTO.getEmail())
+                .password(requestDTO.getPassword())
+                .build();
+
+        userRepository.save(user);
+    }
+}

--- a/spring/week08/seminar/src/main/java/org/example/seminar/service/UserService.java
+++ b/spring/week08/seminar/src/main/java/org/example/seminar/service/UserService.java
@@ -24,7 +24,7 @@ public class UserService {
 
         // 2. 이메일 도메인 검사
         if (!requestDTO.getEmail().endsWith("@sookmyung.ac.kr")) {
-            throw new CustomException(HttpStatus.BAD_REQUEST, "숙명대학교 이메일만 사용할 수 있습니다.");
+            throw new CustomException(HttpStatus.BAD_REQUEST, "숙명여대 이메일만 사용할 수 있습니다.");
         }
 
         // 3. User 엔티티 생성


### PR DESCRIPTION
## 📌 관련 이슈
  closed #52 


## ✨ 과제 내용
<!-- 과제에 대한 설명을 적어주세요 -->
## 📝회원가입 API를 작성하여 유효성 검사와 예외처리 분기하기
### 1. 유효성 검사 (Validation)
DTO를 활용하여 API의 진입점에서 입력값의 유효성을 검사 => 서비스 로직이 실행되기 전에 명백히 잘못된 요청을 차단함
```java
@AllArgsConstructor
@NoArgsConstructor
@ToString
@Getter
public class SignupRequestDTO {

    @NotBlank(message = "아이디는 필수 입력 값입니다.")
    private String username;

    @NotBlank(message = "이메일은 필수 입력 값입니다.")
    @Email(message = "이메일 형식이 올바르지 않습니다.")
    private String email;

    @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
    @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
    private String password;
}

```
- DTO에 Bean Validation 어노테이션을 사용
- `@NotBlank`: null, "", " "(공백문자열)을 모두 허용하지 않음
- `@Email`:  이메일 형식(user@example.com)을 검증함
- `@Size(min=8)`: 문자열의 길이가 최소 8자 이상이어야 함

```java
@RestController
@RequiredArgsConstructor
@RequestMapping("/users")
public class UserController {
    private final UserService userService;

    @PostMapping("/signup")
    public ResponseEntity<String> signup(@Valid @RequestBody SignupRequestDTO signupRequestDTO) {
        userService.signup(signupRequestDTO);
        return ResponseEntity.status(201).body("회원가입 성공");    }
}
```
- `@RequestBody` 앞에 `@Valid` 어노테이션을 추가해 SignupRequestDTO에 정의된 유효성 검사를 자동을 활성화함

### 2. 예외 처리 (Exception Handling)
형식적으로는 유효하지만 서비스의 내부 비즈니스 로직에 위배되는 경우를 처리함. 모든 예외는 @RestControllerAdvice를 통해 일관된 응답으로 변환됨
- UserService
  - 아이디 중복 검사: userRepository의 existsByUsername()으로 DB를 확인하여 중복된 아이디가 존재할 경우 `new CustomException(HttpStatus.CONFLICT, "이미 사용 중인 아이디입니다.");` 발생
  - 이메일 도메인 검사: 숙명 이메일(@sookmyung.ac.kr)이 아닌 경우 `new CustomException(HttpStatus.BAD_REQUEST, "숙명여대 이메일만 사용할 수 있습니다.");` 발생
- HttpStatus
  - HTTP 상태 코드와 메시지를 미리 정의해둔 목록(enum) 
  - ex) 404 NOT_FOUND, 409 CONFLICT
- CustomException
  - 아이디 중복 같이 우리 서비스에서만 발생하는 특정한 비즈니스 에러를 표현하기 위해 직접 만든 예외
- CustomExceptionHandler
  - 애플리케이션의 모든 에러를 붙잡아 처리하는 역할
  - 쓰는 이유: 이 클래스가 없으면 예외가 발생했을 때 사용자는 복잡한 에러 로그를 보게 됨. 이 핸들러가 CustomException 같은 예외를 가로채서 사용자가 이해하기 쉬운 일관된 형식의 에러 메시지로 변환하여 응답해줌

### 3. MethodArgumentNotValidException
- 공백 아이디, 비밀번호 길이 부족, 이메일 형식 오류 같은 형식적인 오류에 대해서도 CustomException과 동일한 일관된 에러 메시지를 제공함
- Controller가 요청을 받음
  -> Spring은 DTO 객체 생성 전에 `@Valid` 확인
  -> DTO 필드에 정의된 유효성 검사 규칙에 위반되는 데이터 발견 시 Spring은 MethodArgumentNotValidException 발생
  -> 즉시 예외 처리 흐름으로 넘어감


## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
### 1. 회원가입 성공
<img width="1235" height="939" alt="성공" src="https://github.com/user-attachments/assets/06225288-e222-40f2-a2f9-159b00db3102" />


## 유효성 검사
### 2. 아이디가 `@NotBlank` 에 걸리는 경우
<img width="1265" height="1000" alt="아이디1" src="https://github.com/user-attachments/assets/054f4017-06e9-49fb-9d1a-c20e9a18b285" />
<img width="1254" height="1013" alt="아이디2" src="https://github.com/user-attachments/assets/084cfc14-112f-436a-87d5-89c9a633d98b" />


### 3. 이메일이 `@Email`에 걸리는 경우
<img width="1252" height="1035" alt="이메일1" src="https://github.com/user-attachments/assets/45f3786c-a7e0-4960-b681-91d498558baf" />


### 4. 비밀번호가 `@Size`에 걸리는 경우
<img width="1241" height="1027" alt="비번" src="https://github.com/user-attachments/assets/f08d05ee-15c0-46d6-b993-c91e62821d72" />


## 예외처리
### 5. 중복된 아이디인 경우
<img width="1259" height="1019" alt="아이디3" src="https://github.com/user-attachments/assets/349a1c4f-7218-4041-90a8-9cf98bfa53b9" />


### 6. 숙명여대 이메일이 아닌 경우
<img width="1246" height="1014" alt="이메일2" src="https://github.com/user-attachments/assets/342cb9b1-1a13-464e-81d3-5dc8a2b596ff" />


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 --> 
### 1. 퀴즈 복습⭕❌
사실 저번 퀴즈의 문제도 제대로 이해하지 못해서 개념 정리를 해보았다 !! 먼저 용어를 정리해보자면
- 빈 문자열 
  - 길이가 0인 문자열
  - 따옴표 안에 아무것도 없는 상태
  - ex) ""
- 공백 문자열
  - 길이는 1 이상이지만 화면에는 아무것도 없는 것처럼 보이는 문자열
  - 하나 이상의 공백, 탭, 줄바꿈 등 눈에 보이지 않는 문자만으로 구성된 문자열
  - ex) "   " (스페이스 1개)
- null
  - 아무것도 없는 상태 (빈 문자열이 빈 상자, 공백 문자열이 투명한 내용물이라면 null은 상자가 없는 상태)

4가지 어노테이션을 비교해보자면
- `@NotNull`: null 값만 허용하지 않음
- `@NotEmpty`: null과 빈 문자열을 허용하지 않음
- `@NotBlank`: null, 빈 문자열, 공백 문자열을 모두 허용하지 않음
- `@Size(min=1)`: null은 허용하지만, 길이는 1 이상이어야 함(= 빈 문자열 허용X)
따라서 빈 문자열을 허용하는 @NotNull이 정답이었다!

### 2. 에러 응답에 대한 나의 오해,,🫢
나는 여태까지 프로젝트를 하면서 아이디나 비밀번호 형식 검증을 프론트에서 해왔었다. 만약에 형식이 잘못되어서 400 bad request 같은 에러를 응답하면 프론트 화면이 멈추게(에러 페이지) 될 거라고 생각했다. 그래서 아이디 중복 검증도 중복인 경우 200 OK로 응답하되 중복 여부를 boolean 값으로 응답하는 식으로 설계했었다. 그래서 이번에 배운 Bean Validation 어노테이션을 사용해서 검증에 걸릴 경우 프론트에서는 어떻게 되는 건가 궁금했다. 인터넷에 찾아보고 윤정 언니에게 물어보니!! 백에서 400 bad request 응답과 함께 에러 정보를 반환하면 에러 정보에 맞게 프론트에서 처리(작게 빨간 글씨로 경고문을 띄운다든지)할 수 있다고 한다 !!! 프론트와 백에서 둘 다에서 검증을 해주는 게 좋다고 한다. Bean Validation 어노테이션 한 줄로 형식 검증을 해줄 수 있는 게 엄청 간편하고 강력한 것 같다. 앞으로 자주 사용해봐야겠다 !
