### PR TITLE
[Feat] 멋사 스프링 10주차 과제

### DIFF
--- a/spring/week10/seminar/src/main/java/org/example/seminar/config/SecurityConfig.java
+++ b/spring/week10/seminar/src/main/java/org/example/seminar/config/SecurityConfig.java
@@ -1,8 +1,10 @@
 package org.example.seminar.config;
 
 import jakarta.servlet.http.HttpServletRequest;
+import org.example.seminar.filter.CustomLogoutFilter;
 import org.example.seminar.filter.JWTFilter;
 import org.example.seminar.filter.LoginFilter;
+import org.example.seminar.repository.RefreshRepository;
 import org.example.seminar.util.JWTUtil;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
@@ -15,6 +17,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 
@@ -26,10 +29,12 @@ public class SecurityConfig {
 
     private final AuthenticationConfiguration authenticationConfiguration;
     private final JWTUtil jwtUtil;
+    private final RefreshRepository refreshRepository;
 
-    public SecurityConfig(AuthenticationConfiguration authenticationConfiguration, JWTUtil jwtUtil){
+    public SecurityConfig(AuthenticationConfiguration authenticationConfiguration, JWTUtil jwtUtil, RefreshRepository refreshRepository){
         this.authenticationConfiguration = authenticationConfiguration;
         this.jwtUtil = jwtUtil;
+        this.refreshRepository = refreshRepository;
     }
 
     @Bean
@@ -85,14 +90,17 @@ public class SecurityConfig {
 
         http
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/", "/login", "/join").permitAll()
+                        .requestMatchers("/", "/login", "/join", "/reissue").permitAll()
                         .anyRequest().authenticated());
 
         http
                 .addFilterBefore(new JWTFilter(jwtUtil), LoginFilter.class);
 
         http
-                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil), UsernamePasswordAuthenticationFilter.class);
+                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration), jwtUtil, refreshRepository), UsernamePasswordAuthenticationFilter.class);
+
+        http
+                .addFilterBefore(new CustomLogoutFilter(jwtUtil, refreshRepository), LogoutFilter.class);
 
         http
                 .sessionManagement((session) -> session

--- a/spring/week10/seminar/src/main/java/org/example/seminar/controller/ReissueController.java
+++ b/spring/week10/seminar/src/main/java/org/example/seminar/controller/ReissueController.java
@@ -1,0 +1,87 @@
+package org.example.seminar.controller;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.example.seminar.entity.RefreshEntity;
+import org.example.seminar.repository.RefreshRepository;
+import org.example.seminar.util.CookieUtil;
+import org.example.seminar.util.JWTUtil;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Date;
+
+@RestController
+public class ReissueController {
+
+    private final JWTUtil jwtUtil;
+    private final RefreshRepository refreshRepository;
+
+    public ReissueController(JWTUtil jwtUtil, RefreshRepository refreshRepository) {
+        this.jwtUtil = jwtUtil;
+        this.refreshRepository = refreshRepository;
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<?> reissue(HttpServletRequest request, HttpServletResponse response) {
+
+        // 쿠키에서 refresh token 추출
+        String refresh = null;
+        Cookie[] cookies = request.getCookies();
+        for (Cookie cookie : cookies) {
+            if (cookie.getName().equals("refresh")) {
+                refresh = cookie.getValue();
+            }
+        }
+
+        if (refresh == null) {
+            return new ResponseEntity<>("refresh token null", HttpStatus.BAD_REQUEST);
+        }
+
+        // 만료되었는지 확인
+        try {
+            jwtUtil.isExpired(refresh);
+        } catch (ExpiredJwtException e) {
+            return new ResponseEntity<>("refresh token expired", HttpStatus.BAD_REQUEST);
+        }
+
+        // 토큰이 refresh인지 확인
+        String category = jwtUtil.getCategory(refresh);
+
+        if (!category.equals("refresh")) {
+            return new ResponseEntity<>("invalid refresh token", HttpStatus.BAD_REQUEST);
+        }
+
+        String username = jwtUtil.getUsername(refresh);
+        String role = jwtUtil.getRole(refresh);
+
+        // 새로운 access/refresh 토큰 만들고
+        String newAccess = jwtUtil.createJwt("access", username, role, 600000L);
+        String newRefresh = jwtUtil.createJwt("refresh", username, role, 86400000L);
+
+        // 기존 refresh 삭제 후, 새로운 refresh 저장
+        refreshRepository.deleteByRefresh(refresh);
+        addRefreshEntity(username, newRefresh, 86400000L);
+
+        // 헤더/쿠키에 추가
+        response.setHeader("access", newAccess);
+        response.addCookie(CookieUtil.createCookie("refresh", newRefresh));
+
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    private void addRefreshEntity(String username, String refresh, Long expiredMs){
+        Date date = new Date(System.currentTimeMillis() + expiredMs);
+
+        RefreshEntity refreshEntity = new RefreshEntity();
+        refreshEntity.setUsername(username);
+        refreshEntity.setRefresh(refresh);
+        refreshEntity.setExpiration(date.toString());
+
+        refreshRepository.save(refreshEntity);
+    }
+}

--- a/spring/week10/seminar/src/main/java/org/example/seminar/entity/RefreshEntity.java
+++ b/spring/week10/seminar/src/main/java/org/example/seminar/entity/RefreshEntity.java
@@ -1,0 +1,23 @@
+package org.example.seminar.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Setter
+@Getter
+public class RefreshEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String username;
+    private String refresh;
+    private String expiration;
+
+}

--- a/spring/week10/seminar/src/main/java/org/example/seminar/filter/CustomLogoutFilter.java
+++ b/spring/week10/seminar/src/main/java/org/example/seminar/filter/CustomLogoutFilter.java
@@ -1,0 +1,110 @@
+package org.example.seminar.filter;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.example.seminar.repository.RefreshRepository;
+import org.example.seminar.util.JWTUtil;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+
+public class CustomLogoutFilter extends GenericFilterBean {
+
+    private final JWTUtil jwtUtil;
+    private final RefreshRepository refreshRepository;
+
+    public CustomLogoutFilter(JWTUtil jwtUtil, RefreshRepository refreshRepository) {
+
+        this.jwtUtil = jwtUtil;
+        this.refreshRepository = refreshRepository;
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain)
+            throws IOException, ServletException {
+
+        doFilter((HttpServletRequest) request, (HttpServletResponse) response, filterChain);
+    }
+
+    private void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws IOException, ServletException {
+
+        // /logout 경로로의 POST요청인지 확인
+        String requestUri = request.getRequestURI();
+        if (!requestUri.matches("^\\/logout$")) {
+
+            filterChain.doFilter(request, response);
+            return;
+        }
+        String requestMethod = request.getMethod();
+        if (!requestMethod.equals("POST")) {
+
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // 쿠키에서 refresh 토큰 추출
+        String refresh = null;
+        Cookie[] cookies = request.getCookies();
+        for (Cookie cookie : cookies) {
+
+            if (cookie.getName().equals("refresh")) {
+
+                refresh = cookie.getValue();
+            }
+        }
+
+        // refresh 토큰이 null인지 체크
+        if (refresh == null) {
+
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        // 토큰 만료되었는지 체크
+        try {
+            jwtUtil.isExpired(refresh);
+        } catch (ExpiredJwtException e) {
+
+            //response status code
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        // 토큰이 refresh인지 확인
+        String category = jwtUtil.getCategory(refresh);
+        if (!category.equals("refresh")) {
+
+            //response status code
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        // DB에 저장되어 있는지 확인
+        Boolean isExist = refreshRepository.existsByRefresh(refresh);
+        if (!isExist) {
+
+            //response status code
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        //로그아웃 진행
+        //Refresh 토큰 DB에서 제거
+        refreshRepository.deleteByRefresh(refresh);
+
+        //Refresh 토큰 Cookie 값 0
+        Cookie cookie = new Cookie("refresh", null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+
+        response.addCookie(cookie);
+        response.setStatus(HttpServletResponse.SC_OK);
+    }
+}

--- a/spring/week10/seminar/src/main/java/org/example/seminar/filter/JWTFilter.java
+++ b/spring/week10/seminar/src/main/java/org/example/seminar/filter/JWTFilter.java
@@ -1,5 +1,6 @@
 package org.example.seminar.filter;
 
+import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -13,6 +14,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.io.PrintWriter;
 
 public class JWTFilter extends OncePerRequestFilter {
 
@@ -25,35 +27,44 @@ public class JWTFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
-        // 요청에서 Authorization 헤더를 찾음
-        String authorization = request.getHeader("Authorization");
+        // 헤더에서 access 키에 담기 토큰을 꺼냄
+        String accessToken = request.getHeader("access");
 
-        // Authorization 헤더 검증
-        if (authorization == null || !authorization.startsWith("Bearer ")) {
-            System.out.println("token null");
-            filterChain.doFilter(request, response); // 다음 필터로 전달
-
-            // 메소드 종료
+        // 토큰 없다면 다음 필터로
+        if (accessToken == null) {
+            filterChain.doFilter(request, response);
             return;
         }
 
-        System.out.println("authorization now");
+        // 토큰 만료 여부 확인
+        try {
+            jwtUtil.isExpired(accessToken);
+        } catch (ExpiredJwtException e) {
 
-        // Bearer 부분 제거하여 토큰 획득
-        String token = authorization.split(" ")[1];
+            // response body
+            PrintWriter writer = response.getWriter();
+            writer.print("access token expired");
 
-        // 토큰 소멸 시간 검증
-        if (jwtUtil.isExpired(token)) {
-            System.out.println("token expired");
-            filterChain.doFilter(request, response);
+            // response status code
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
 
-            // 메소드 종료
+        // 토큰이 access 인지 확인
+        String category = jwtUtil.getCategory(accessToken);
+
+        if (!category.equals("access")) {
+
+            PrintWriter writer = response.getWriter();
+            writer.print("invalid access token");
+
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             return;
         }
 
         // 토큰에서 username과 role 획득
-        String username = jwtUtil.getUsername(token);
-        String role = jwtUtil.getRole(token);
+        String username = jwtUtil.getUsername(accessToken);
+        String role = jwtUtil.getRole(accessToken);
 
         // User를 생성하여 값 설정
         User user = new User();
@@ -61,11 +72,12 @@ public class JWTFilter extends OncePerRequestFilter {
         user.setPassword("temppassword"); // 임의로 설정
         user.setRole(role);
 
-        // userDetails에 회원 정보 객체 담기
-        CustomUserDetails customuserDetails = new CustomUserDetails(user);
+        // UserDetails에 회원 정보 객체 담기
+        CustomUserDetails customUserDetails = new CustomUserDetails(user);
 
         // 스프링 시큐리티 인증 토큰 생성
-        Authentication authToken = new UsernamePasswordAuthenticationToken(customuserDetails, null, customuserDetails.getAuthorities());
+        Authentication authToken = new UsernamePasswordAuthenticationToken(customUserDetails, null,
+                customUserDetails.getAuthorities());
 
         // 세션에 사용자 등록
         SecurityContextHolder.getContext().setAuthentication(authToken);

--- a/spring/week10/seminar/src/main/java/org/example/seminar/filter/LoginFilter.java
+++ b/spring/week10/seminar/src/main/java/org/example/seminar/filter/LoginFilter.java
@@ -4,6 +4,8 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.example.seminar.dto.CustomUserDetails;
+import org.example.seminar.entity.RefreshEntity;
+import org.example.seminar.repository.RefreshRepository;
 import org.example.seminar.util.CookieUtil;
 import org.example.seminar.util.JWTUtil;
 import org.springframework.http.HttpStatus;
@@ -15,16 +17,19 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 import java.util.Collection;
+import java.util.Date;
 import java.util.Iterator;
 
 public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
     private final AuthenticationManager authenticationManager;
     private final JWTUtil jwtUtil;
+    private final RefreshRepository refreshRepository;
 
-    public LoginFilter(AuthenticationManager authenticationManager, JWTUtil jwtUtil) {
+    public LoginFilter(AuthenticationManager authenticationManager, JWTUtil jwtUtil, RefreshRepository refreshRepository) {
         this.authenticationManager = authenticationManager;
         this.jwtUtil = jwtUtil;
+        this.refreshRepository = refreshRepository;
     }
 
     @Override
@@ -44,6 +49,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     @Override
     protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response,
                                             FilterChain chain, Authentication authentication) {
+
         CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
         String username = customUserDetails.getUsername();
 
@@ -54,12 +60,15 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         String role = auth.getAuthority();
 
         // 토큰 생성
-        String access = jwtUtil.createJwt("access", username, role, 60 * 10 * 1000L); // Access
-        String refresh = jwtUtil.createJwt("refresh", username, role, 24 * 60 * 1000L);
+        String access = jwtUtil.createJwt("access", username, role, 60 * 10 * 1000L);
+        String refresh = jwtUtil.createJwt("refresh", username, role, 24 * 60 * 60 * 1000L);
+
+        // refresh 토큰 저장
+        addRefreshEntity(username, refresh, 86400000L);
 
         // 응답 설정
         response.setHeader("access", access);
-        response.addCookie(CookieUtil.creatCookie("refresh", refresh));
+        response.addCookie(CookieUtil.createCookie("refresh", refresh));
         response.setStatus(HttpStatus.OK.value());
     }
 
@@ -69,5 +78,15 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         response.setStatus(401);
     }
 
+    private void addRefreshEntity(String username, String refresh, Long expiredMs){
+        Date date = new Date(System.currentTimeMillis() + expiredMs);
+
+        RefreshEntity refreshEntity = new RefreshEntity();
+        refreshEntity.setUsername(username);
+        refreshEntity.setRefresh(refresh);
+        refreshEntity.setExpiration(date.toString());
+
+        refreshRepository.save(refreshEntity);
+    }
 }
 

--- a/spring/week10/seminar/src/main/java/org/example/seminar/repository/RefreshRepository.java
+++ b/spring/week10/seminar/src/main/java/org/example/seminar/repository/RefreshRepository.java
@@ -1,0 +1,13 @@
+package org.example.seminar.repository;
+
+import org.example.seminar.entity.RefreshEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface RefreshRepository extends JpaRepository<RefreshEntity, Long> {
+
+    Boolean existsByRefresh(String refresh);
+
+    @Transactional
+    void deleteByRefresh(String refresh);
+}

--- a/spring/week10/seminar/src/main/java/org/example/seminar/util/CookieUtil.java
+++ b/spring/week10/seminar/src/main/java/org/example/seminar/util/CookieUtil.java
@@ -3,7 +3,7 @@ package org.example.seminar.util;
 import jakarta.servlet.http.Cookie;
 
 public class CookieUtil {
-    public static Cookie creatCookie(String key, String value) {
+    public static Cookie createCookie(String key, String value) {
         Cookie cookie = new Cookie(key, value);
         cookie.setMaxAge(24 * 60 * 60);
         //cookie.setSecure(true);


### PR DESCRIPTION
## 📌 관련 이슈
  closed #56 


## ✨ 과제 내용
<!-- 과제에 대한 설명을 적어주세요 -->
### Spring Security와 JWT를 사용한 인증/인가 구현
### 1. 회원가입
1. 클라이언트가 ID와 비밀번호를 담아 POST /join 경로로 회원가입 요청
2. JoinController가 요청 수신하여 JoinService 호출
3. JoinService
    - UserRepository를 통해 username 중복 확인
    - BCryptPasswordEncoder로 비밀번호 암호화
    - User 정보 DB에 저장
4. 회원가입 성공 응답 (201 CREATED)

### 2. 로그인 및 토큰 발급
1. 클라이언트가 ID와 비밀번호로 POST /login 경로로 로그인 요청
2. LoginFilter가 요청을 가로채 인증 시도
    - AuthenticationManager에 인증 위임
    - CustomUserDetailsService가 DB에서 사용자 정보 조회 후 비밀번호 비교
3. 인증 성공 시 (successfulAuthentication)
    - JWTUtil 을 통해 Access Token과 Refresh Token 생성
    - RefreshRepository를 통해 Refresh Token을 저장하여 서버에 보관
    - Access Token은 응답 헤더에 담아 전달
    - Refresh Token은 HttpOnly 쿠키에 담아 전달
4. 로그인 성공 응답 (200 OK) & Tokens

### 3. 인증이 필요한 API 요청
1. 클라이언트는 발급받은 Access Token을 HTTP 헤더에 담아 /main 경로로 API를 요청
2. JWTFilter가 요청을 가로채 헤더의 Access Token 검증
    - 토큰 유효성 (만료 여부, 타입 등) 확인
3. 검증 성공 시
    - 토큰에서 username과 role 추출
    - SecurityContextHolder에 인증 정보 등록 -> "현재 요청은 인증된 사용자" 임을 명시
    - 요청을 Controller로 전달
4. MainController가 요청을 처리하여 결과 반환
5. JWTFilter에서 토큰 만료 시: 401 Unauthorized 에러 응답

### 4. Access Token 재발급
1. 클라이언트에서 Access Token이 만료되면 브라우저에 저장된 Refresh Token과 함께 /reissue 경로로 토큰 재발급을 요청

2. ReissueController 가 요청 수신
    - 쿠키에서 Refresh Token 추출
    - JWTUtil로 토큰 유효성 검증
    - RefreshRepository 에서 DB에 저장된 토큰과 일치하는지 확인
   
3. 검증 성공 시
    - 기존 Refresh Token을 DB에서 삭제
    - 새로운 Access Token과 Refresh Token 생성
    - RefreshRepository 에 새 Refresh Token 저장
    
4. 새로운 토큰 발급 

### 5. 로그아웃
1. 클라이언트가 /logout 경로로 로그아웃을 요청하면, 브라우저의 Refresh Token이 요청에 담겨 함께 전송됨
2. CustomLogoutFilter 가 요청을 가로채 처리
    - 쿠키에서 Refresh Token 추출
    - RefreshRepository 에서 해당 Refresh Token을 삭제
    - 클라이언트의 Refresh Token 쿠키를 만료 처리하여 삭제
3. 로그아웃 성공 응답 (200 OK)

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
### 1. 회원가입
<img width="1229" height="936" alt="join" src="https://github.com/user-attachments/assets/f2be4c82-a70e-433a-bdfb-8419199c79af" />

### 2. 로그인
<img width="1248" height="1476" alt="login-headers" src="https://github.com/user-attachments/assets/7c58bcb2-d960-42e4-97b9-ca213837b647" />
응답 헤더에 Access 토큰
<img width="2605" height="1144" alt="login-cookie" src="https://github.com/user-attachments/assets/ff0d4f99-8955-465a-84fc-8120800af2ff" />
쿠키에는 Refresh 토큰
<img width="2858" height="876" alt="db-refresh" src="https://github.com/user-attachments/assets/a67f5c7b-3bb0-4f3d-98f5-af9ba203033b" />
DB에도 Refresh 토큰 저장

### 3. 토큰 재발급
<img width="2608" height="1475" alt="reissue" src="https://github.com/user-attachments/assets/6ad8b6ce-8bc1-470e-8d40-cb08c2ca767b" />

- 재발급 요청을 보내면 새로운 Access 토큰이 응답 헤더로 발급됨
- 요청 쿠키에 Refresh가 자동으로 추가됨

<img width="2627" height="1263" alt="reissue-cookie" src="https://github.com/user-attachments/assets/ee25360b-cba4-49cf-beae-0e7b14097e5e" />
새로운 Refresh 토큰은 쿠키로 발급

### 4. 로그아웃
<img width="2603" height="1058" alt="logout" src="https://github.com/user-attachments/assets/09f039b8-090e-4720-84a4-c307b6b367b2" />
로그아웃 요청을 보내면 Headers의 set-Cookie 값이 사라짐 (쿠키 초기화 설정을 했기 때문)
<img width="2864" height="906" alt="logout db" src="https://github.com/user-attachments/assets/2b848262-a20e-438d-803f-0f7ae6f9a6ba" />
DB에도 Refresh 토큰이 삭제됨

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
### 토큰은 왜 헤더와 쿠키에 나누어 전달할까?
Access Token과 Refresh Token을 헤더와 쿠키에 나누어 저장하는 이유가 궁금해 찾아보았다. 결론부터 말하면 더 중요하고 오래 살아있는 Refresh Token을 가장 안전한 HttpOnly 쿠키에 보관하기 위해서다.

1. Access Token을 Header에 저장하는 이유
Access Token은 API를 요청할 때마다 서버에 자신이 인증된 사용자임을 증명하기 위해 사용한다. 서버는 요청 헤더만 보고도 어떤 사용자인지 바로 알 수 있어 상태를 저장할 필요가 없다. 하지만 API를 호출할 때마다 네트워크를 통해 전송되므로 두 토큰 중에서는 탈취될 위험에 더 자주 노출된다. 이 위험을 완화하기 위해 유효 기간을 매우 짧게 설정한다.

2. Refresh Token은 왜 HttpOnly 쿠키에 저장하는가?
Refresh Token은 Access Token을 새로 발급하기 위해 사용되며 유효 기간이 길기 때문에 탈취되면 매우 위험하다. 따라서 가장 안전한 곳에 보관해야 한다. 그렇다면 Refresh Token도 유효기간을 짧게 하면 되지 않을까 생각했는데, 그러면 굳이 두 개의 토큰을 사용하는 의미가 사라지고 사용자 경험이 나빠진다. (Access Token은 만료되면 사용자는 모르게 Refresh Token으로 새로운 Access Token을 재발급받아 서비스를 계속 사용하지만, Refresh Token마저 만료되면 중간에 갑자기 로그인이 풀리고 로그인 페이지로 튕겨 나가게 된다.)

본론으로 돌아와 HttpOnly와 XSS 공격 방어에 대해서 조금 알아보자면 
HttpOnly 속성이 적용된 쿠키는 웹브라우저의 특별한 저장소로 다음과 같은 핵심 규칙이 있다. 
=> 이 쿠키는 오직 서버와 통신할 때만 사용될 수 있으며 웹사이트의 자바스크립트 코드로는 절대 접근할 수 없다.
이 규칙이 중요한 이유는 웹에서 가장 흔한 공격 중 하나인 XSS 공격을 막아주기 때문이다.
- XSS (Cross-Site-Scripting) 공격이란?
1. 공격자가 웹사이트의 게시판이나 댓글 창에 악성 자바스크립트 코드를 심어 놓음
2. 다른 사용자가 해당 게시물을 클릭하면 그 사용자의 브라우저에서 악성 스크립트가 실행됨
3. 스크립트는 브라우저의 저장소 (localstorage, 일반 쿠키 등)을 뒤져서 Access Token이나 Refresh Token을 훔쳐 공격자의 서버로 전송함

Refresh Token을 HttpOnly 쿠키에 저장하면 악성 스크립트가 아무리 브라우저 저장소를 뒤져도 이 쿠키의 존재 자체를 알 수 없다. 자바스크립트의 접근이 원천적으로 차단되기 때문이다 !! 따라서 Refresh Token을 이러한 공격으로부터 보호하기 위해 HttpOnly 쿠키에 저장하는 것이다.
